### PR TITLE
Java8 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,11 @@
   			<artifactId>cristalise-ldap</artifactId>
   			<version>3.1-SNAPSHOT</version>
   		</dependency>
+  		<dependency>
+  			<groupId>org.cristalise</groupId>
+  			<artifactId>cristalise-js-rhino</artifactId>
+  			<version>1.0</version>
+  		</dependency>
   	</dependencies>
   </dependencyManagement>
   <dependencies>
@@ -209,6 +214,10 @@
   	<dependency>
   		<groupId>org.cristalise</groupId>
   		<artifactId>cristalise-ldap</artifactId>
+  	</dependency>
+  	<dependency>
+  		<groupId>org.cristalise</groupId>
+  		<artifactId>cristalise-js-rhino</artifactId>
   	</dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Bring in cristalise-js-rhino to make sure all the scripts use Rhino instead of the incompatible Nashorn on Java8
